### PR TITLE
イベント作成画面

### DIFF
--- a/training/app/action/Create/Do.php
+++ b/training/app/action/Create/Do.php
@@ -75,6 +75,7 @@ class Sharepictures_Form_CreateDo extends Sharepictures_ActionForm
      */
     public function checkFile($pictureArray)
     {
+        if ($this->form_vars[$pictureArray] !== null && $this->form_vars[$pictureArray][0]['name'] !== "") {
         foreach ($this->form_vars[$pictureArray] as $picture) {
             // .jpeg ,jpeg以外はエラー
             if (exif_imagetype($picture['tmp_name']) !== IMAGETYPE_JPEG) {
@@ -84,6 +85,7 @@ class Sharepictures_Form_CreateDo extends Sharepictures_ActionForm
                 $this->ae->add($pictureArray, 'ファイルサイズが大き過ぎます。', E_FORM_INVALIDVALUE);
             }
         }
+      }
     }
 }
 

--- a/training/app/action/Create/Do.php
+++ b/training/app/action/Create/Do.php
@@ -5,7 +5,6 @@
  *  @author     {$author}
  *  @package    Sharepictures
  */
-require_once('adodb5/adodb.inc.php');
 /**
  *  create_do Form implementation.
  *

--- a/training/app/action/Create/Do.php
+++ b/training/app/action/Create/Do.php
@@ -74,17 +74,21 @@ class Sharepictures_Form_CreateDo extends Sharepictures_ActionForm
      */
     public function checkFile($pictureArray)
     {
-        if ($this->form_vars[$pictureArray] !== null && $this->form_vars[$pictureArray][0]['name'] !== "") {
+        if (is_null($this->form_vars[$pictureArray]) || $this->form_vars[$pictureArray][0]['name'] === "") {
+            return;
+        }
+
         foreach ($this->form_vars[$pictureArray] as $picture) {
             // .jpeg ,jpeg以外はエラー
             if (exif_imagetype($picture['tmp_name']) !== IMAGETYPE_JPEG) {
                 $this->ae->add($pictureArray, 'ファイル形式に誤りがあります。', E_FORM_INVALIDVALUE);
+                return;
             }
             if ($picture['size'] > 5000000) {
                 $this->ae->add($pictureArray, 'ファイルサイズが大き過ぎます。', E_FORM_INVALIDVALUE);
+                return;
             }
         }
-      }
     }
 }
 
@@ -129,18 +133,18 @@ class Sharepictures_Action_CreateDo extends Sharepictures_ActionClass
             $pictureArray[] = $uploadfile;
         }
 
-          //  セッション開始
-          $sessionarray = [
-              'title'   =>    $this->af->get('title'),
-              'release_date'    =>    $this->af->get('release_date'),
-              'end_date'    =>    $this->af->get('end_date'),
-              'picture_array'   =>    $pictureArray,
-            ];
+        //  セッション開始
+        $sessionarray = [
+            'title'   =>    $this->af->get('title'),
+            'release_date'    =>    $this->af->get('release_date'),
+            'end_date'    =>    $this->af->get('end_date'),
+            'picture_array'   =>    $pictureArray,
+        ];
 
-          $this->session->set('create', $sessionarray);
-          $this->session->start('create');
+        $this->session->set('create', $sessionarray);
+        $this->session->start('create');
 
-          return 'confirm';
+        return 'confirm';
     }
 
     /**

--- a/training/app/action/Create/Do.php
+++ b/training/app/action/Create/Do.php
@@ -61,9 +61,9 @@ class Sharepictures_Form_CreateDo extends Sharepictures_ActionForm
      */
     public function checkDateInterval($endDate)
     {
-        $interval = ($this->form_vars[$endDate] - $this->form_vars['release_date']) / (60 * 60 * 24);
-
-        if ($interval < 0) {
+        $eDate = new Datetime($this->form_vars[$endDate]);
+        $rDate = new DateTime($this->form_vars['release_date']);
+        if ($eDate < $rDate) {
             $this->ae->add($endDate, '公開開始日より後の日付を選択してください', E_FORM_INVALIDVALUE);
         }
     }


### PR DESCRIPTION
- バリデーション（公開日数とファイル拡張子）の修正を行いました。以下が修正理由です。
  - 公開日数のバリデーション：日付データの扱い方が間違っていたため
  - ファイル拡張子のバリデーション：ファイル配列がnullの場合や無名ファイルが送信された場合に対応するため
